### PR TITLE
Fix alignment of org logos

### DIFF
--- a/transformation/assets/stylesheets/whitehall/_organisations.scss
+++ b/transformation/assets/stylesheets/whitehall/_organisations.scss
@@ -1,3 +1,25 @@
+.organisation-logo {
+  font-family: Helvetica, Arial;
+  font-weight: 400;
+  display: block;
+  position: relative;
+  background-repeat: no-repeat;
+  font-size: 13px;
+  line-height: 15px;
+  padding: 3px 0 2px 0;
+
+  &:link,
+  &:visited {
+    color: #000;
+  }
+
+  span {
+    color: #000;
+    padding: 0;
+    margin: 0;
+  }
+}
+
 .organisation-logo-stacked-no-identity {
 }
 .organisation-logo-identity {
@@ -18,6 +40,7 @@
   @extend .organisation-logo-identity;
 
   background-image: url(https://assets.digital.cabinet-office.gov.uk/government/assets/crests/org_crest_13px-ff51bae73255332e49fd9390e039c37a.png);
+  padding: 20px 0 0 6px;
   background-position: 5px top;
   background-size: auto 20px;
 }
@@ -46,6 +69,7 @@
   @extend .organisation-logo-identity;
 
   background-image: url(https://assets.digital.cabinet-office.gov.uk/government/assets/crests/bis_crest_13px-5163d02686b4a53180953e9bfff973a7.png);
+  padding: 20px 0 0 6px;
   background-position: 5px top;
   background-size: auto 20px;
 }
@@ -74,6 +98,7 @@
   @extend .organisation-logo-identity;
 
   background-image: url(https://assets.digital.cabinet-office.gov.uk/government/assets/crests/ho_crest_13px-b6c35fe92b71fca8290dc9a65f03d66c.png);
+  padding: 25px 0 0 6px;
   background-position: 5px top;
   background-size: auto 25px;
 }
@@ -102,6 +127,7 @@
   @extend .organisation-logo-identity;
 
   background-image: url(https://assets.digital.cabinet-office.gov.uk/government/assets/crests/hmrc_crest_13px-980149bdc5c6317c51aa27b50355d988.png);
+  padding: 20px 0 0 6px;
   background-position: 5px top;
   background-size: auto 20px;
 }
@@ -145,8 +171,8 @@
 .organisation-logo-stacked-single-identity-medium {
   @extend .organisation-logo-identity-medium;
   @include media(tablet){
-
     background-image: url(https://assets.digital.cabinet-office.gov.uk/government/assets/crests/org_crest_18px-0d15a5b24181c00d5a39e015b2e894e3.png);
+    padding: 25px 0 0 7px;
     background-position: 6px top;
     background-size: auto 25px;
   }
@@ -178,8 +204,8 @@
 .organisation-logo-stacked-bis-medium {
   @extend .organisation-logo-identity-medium;
   @include media(tablet){
-
     background-image: url(https://assets.digital.cabinet-office.gov.uk/government/assets/crests/bis_crest_18px-e0ad84b8f02a467177eed65775fc9ffa.png);
+    padding: 25px 0 0 7px;
     background-position: 6px top;
     background-size: auto 25px;
   }
@@ -211,8 +237,8 @@
 .organisation-logo-stacked-ho-medium {
   @extend .organisation-logo-identity-medium;
   @include media(tablet){
-
     background-image: url(https://assets.digital.cabinet-office.gov.uk/government/assets/crests/ho_crest_18px-6607634d62bea5b5bd6c57de6ab9d7d0.png);
+    padding: 35px 0 0 7px;
     background-position: 6px top;
     background-size: auto 35px;
   }
@@ -244,8 +270,8 @@
 .organisation-logo-stacked-hmrc-medium {
   @extend .organisation-logo-identity-medium;
   @include media(tablet){
-
     background-image: url(https://assets.digital.cabinet-office.gov.uk/government/assets/crests/hmrc_crest_18px-f569ad3e7d4389b8b79e7f30c77288e9.png);
+    padding: 25px 0 0 7px;
     background-position: 6px top;
     background-size: auto 25px;
   }


### PR DESCRIPTION
Org logos were getting padding from static. This resets that padding and
adds custom padding for each logo type. It also includes the basic reset
for org logos including the font and such.
