### PR TITLE
Fix #6

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -2,6 +2,15 @@
 
 set -e
 
+if [ $(find . -name '*.orig' -type f | grep -c .) -ne 0 ]; then
+  echo "You seem to have some git merge artifacts on the filesystem. Aborting..."
+  exit 1
+fi
+
+echo "Updating submodules to ensure toolkit up to date..."
+git submodule update --init
+echo "Updated."
+
 DESIGN_PRINCIPLES_ROOT="../design-principles"
 DIRECTORY="$DESIGN_PRINCIPLES_ROOT/public"
 GUIDANCE_PATH="$DIRECTORY/transformation"


### PR DESCRIPTION
Update fronted toolkit as part of compile, and check for git merge
problems which can cause broken links to be deployed.
