### PR TITLE
We don't need search in the header

### DIFF
--- a/_includes/_header.html
+++ b/_includes/_header.html
@@ -8,15 +8,7 @@
         </a>
         <a href="#search" class="search-toggle js-header-toggle">Search</a>
       </div>
-
-      <form id="search" class="site-search" action="/service-manual/search" method="get">
-          <div class="content">
-            <label for="site-search-text">Search GOV.UK</label>
-            <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus" role="search">
-            <input class="submit" type="submit" value="Search" />
-          </div>
-        </form>
-      </div>
     </div>
-  </header>
+  </div>
+</header>
 <!--end header-->


### PR DESCRIPTION
Firstly, it was pointing at service manual search
Secondly, there isn't much content to search here and these pages currently sit outside of GOV.UK search.

This should fix #7 
