### PR TITLE
Tweaking title and meta description tags

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -1,5 +1,5 @@
 <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-<title>Digital Transformation{% if page.title %} of {{ page.title | downcase }}{% endif %} - GOV.UK</title>
+<title>Digital Transformation{% if page.title %} of {{ page.title | downcase }}{% endif %} – GOV.UK</title>
 <meta name="description" content="Digital services so good people prefer to use them. The Government Digital Strategy and departmental digital strategies commit us to the redesigning and rebuilding of 25 significant 'exemplar' services. We're going to make them simpler, clearer and faster to use.">
 
 {% include _head.assets.html %}


### PR DESCRIPTION
Adding some small clarity to title tags, and using the transformation blurb instead of gov.uk for meta description.
