### PR TITLE
Fixing broken links on dashboard update section

### DIFF
--- a/transformation/index.html
+++ b/transformation/index.html
@@ -65,8 +65,8 @@ breadcrumbs:
       <h3>This month&rsquo;s highlights</h3>
       <ul>
         <li>The <a href="/transformation/passports">Passports</a> exemplar has completed discovery</li>
-        <li>The <a href="/transformation/visas">Visas</a> exemplar moved to private beta</li>
-        <li>The beta build has started on <a href="/transformation/redundancy-payments">Redundancy payments</a></li>
+        <li>The <a href="/transformation/apply-visa">Visas</a> exemplar moved to private beta</li>
+        <li>The beta build has started on <a href="/transformation/redundancy-payment">Redundancy payments</a></li>
         <li><a href="/transformation/apprenticeships">Apprenticeship applications</a> exemplar moved into alpha</li>
         <li>HMRC released a private beta for <a href="/transformation/paye">PAYE for employees</a>, <a href="/transformation/self-assessment">Digital self-assessment</a> and <a href="/transformation/business-tax-account">Your tax account</a> with around 2,000 invited users</li>
       </ul>


### PR DESCRIPTION
Two bad links slipped through during the monthly update. Fixes here.
