### PR TITLE
Add assets pipeline folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .sass-cache/
 _site/
 .search-index.json
+_assets_pipeline


### PR DESCRIPTION
An assets pipeline folder exists within #47 - should be ignored until that's merged.
