### PR TITLE
Update the link to Personalised Registrations

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -56,7 +56,7 @@ Twenty exemplar services were publicly available. The remaining 5 are still in d
 - [Rural payments](https://www.gov.uk/claim-rural-payments)
 - [Waste carrier registration](https://www.gov.uk/waste-carrier-or-broker-registration)
 - [Vehicle management](https://www.gov.uk/motor-traders-sale-vehicle)
-- [Personalised registration](https://www.gov.uk/buy-a-personalised-registration-number)
+- [Personalised registration](https://www.gov.uk/keep-registration-number)
 - [Redundancy payments](https://www.gov.uk/claim-redundancy)
 
 ### Still in development


### PR DESCRIPTION
This is Zendesk Ticket #1024046, where it is noted that the link for Personalised Registrations points to the old service for buying registrations, not the new service. This PR updates the URL to point to the new service.