### PR TITLE
Remove Google Analytics classic

### DIFF
--- a/_assets_pipeline/javascripts/analytics-init.js
+++ b/_assets_pipeline/javascripts/analytics-init.js
@@ -1,17 +1,16 @@
 (function() {
   "use strict";
 
-  GOVUK.Tracker.load();
+  GOVUK.Analytics.load();
   var cookieDomain = (document.domain === 'www.gov.uk') ? '.www.gov.uk' : document.domain;
 
-  GOVUK.analytics = new GOVUK.Tracker({
-    universalId: 'UA-26179049-7',
-    classicId: 'UA-26179049-1',
+  GOVUK.analytics = new GOVUK.Analytics({
+    universalId: 'UA-26179049-1',
     cookieDomain: cookieDomain
   });
 
   if (window.devicePixelRatio) {
-    GOVUK.analytics.setDimension(11, window.devicePixelRatio, 'Pixel Ratio', 2);
+    GOVUK.analytics.setDimension(11, window.devicePixelRatio);
   }
 
   GOVUK.analytics.trackPageview();

--- a/_assets_pipeline/javascripts/app.js
+++ b/_assets_pipeline/javascripts/app.js
@@ -2,9 +2,8 @@
 //= require ./vendor/jquery/jquery-migrate-1.2.1.js
 //= require ./vendor/jquery/jquery-ui-1.10.4.js
 //= require ../govuk_toolkit/javascripts/vendor/jquery/jquery.player.min.js
-//= require ../govuk_toolkit/javascripts/govuk/analytics/google-analytics-classic-tracker.js
 //= require ../govuk_toolkit/javascripts/govuk/analytics/google-analytics-universal-tracker.js
-//= require ../govuk_toolkit/javascripts/govuk/analytics/tracker.js
+//= require ../govuk_toolkit/javascripts/govuk/analytics/analytics.js
 //= require analytics-init.js
 
 // Avoid `console` errors in browsers that lack a console.


### PR DESCRIPTION
__To be deployed 2 June.__

Following on from https://github.com/alphagov/govuk_frontend_toolkit/pull/194

* Bump govuk_frontend_toolkit to pull in latest analytics
* Remove references to classic tracker
* Remove classic specific arguments (eg custom variable name and scope)
* Update references of `GOVUK.Tracker` to `GOVUK.Analytics`